### PR TITLE
added a backoff decorator that indefinitely retries to fetch when the…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,9 @@ UltiPro SOAP Python is a Python client that wraps the UltiPro SOAP API.
 
 setup(
     name='ultipro',
-    version='0.0.2',
+    version='0.0.3',
     url='https://github.com/call/ultipro-soap-python',
-    author_email='bizappdev@puppet.com',
+    author_email=['bizappdev@puppet.com', 'jonathan.revah@equinox.com'],
     packages=['ultipro', 'ultipro.services'],
     license='Apache License 2.0',
     install_requires=[

--- a/ultipro/services/bi_stream.py
+++ b/ultipro/services/bi_stream.py
@@ -8,6 +8,7 @@ import backoff # Helps handle intermittent 405 errors from server
 endpoint = 'BiStreamingService'
 
 @backoff.on_exception(backoff.expo, requests.exceptions.HTTPError, max_tries=8, on_backoff=backoff_hdlr)
+@backoff.on_predicate(backoff.fibo, lambda x: x['header']['Status'] == 'Working', on_backoff=backoff_hdlr)
 def retrieve_report(client, report_key):
     zeep_client = ZeepClient(f"{client.base_url}{endpoint}")
     return zeep_client.service.RetrieveReport(_soapheaders={'ReportKey': report_key})


### PR DESCRIPTION
# Issue

Running this package on reports that either take a long time or are being queued up generates the error below.

```
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.7/bin/ultipro", line 11, in <module>
    load_entry_point('ultipro', 'console_scripts', 'ultipro')()
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/heyoni/source/work/ultipro-soap-python/ultipro/cli.py", line 160, in report
    data = bi_reports.execute_and_fetch(client, report_path)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/backoff/_sync.py", line 85, in retry
    ret = target(*args, **kwargs)
  File "/Users/heyoni/source/work/ultipro-soap-python/ultipro/services/bi_reports.py", line 13, in execute_and_fetch
    return r['body']['ReportStream'].decode('unicode-escape')
AttributeError: 'NoneType' object has no attribute 'decode'
```

The reason being that the ultipro API is returning the following response:

```
{
    'header': {
        'Status': 'Working',
        'StatusMessage': None,
        '_raw_elements': [
            <Element {http://www.w3.org/2005/08/addressing}Action at 0x1128506c8>,
            <Element {http://www.w3.org/2005/08/addressing}RelatesTo at 0x112850bc8>
        ]
    },
    'body': {
        'ReportStream': None
    }
}
```

# Fix
If the header explicitly mentions that the report is being worked on, keep trying to fetch it. It sometimes may take a long time but at least it means things are being worked on and there is no reason to discard the report key and try again.

To keep things consistent, I added a check in the form of a `backoff.predicate` decorator that looks at the status and restarts `retrieve_report` when it's equal to `Working`.